### PR TITLE
Add bar duration parameter to Alpaca's history feed

### DIFF
--- a/roboquant-extra/src/alpaca/AlpacaHistoricFeed.kt
+++ b/roboquant-extra/src/alpaca/AlpacaHistoricFeed.kt
@@ -103,7 +103,12 @@ class AlpacaHistoricFeed(
     /**
      * Retrieve for a number of [symbols] and specified [timeframe] the [PriceBar].
      */
-    fun retrieveBars(vararg symbols: String, timeframe: Timeframe, period: AlpacaPeriod = AlpacaPeriod.DAY) {
+    fun retrieveBars(
+        vararg symbols: String,
+        timeframe: Timeframe,
+        period: AlpacaPeriod = AlpacaPeriod.DAY,
+        barTimePeriodDuration: Int = 1,
+    ) {
         for (symbol in symbols) {
             val resp = alpacaAPI.stockMarketData().getBars(
                 symbol,
@@ -111,7 +116,7 @@ class AlpacaHistoricFeed(
                 ZonedDateTime.ofInstant(timeframe.end, zoneId),
                 null,
                 null,
-                1,
+                barTimePeriodDuration,
                 period,
                 BarAdjustment.ALL,
                 BarFeed.IEX

--- a/roboquant-extra/test/alpaca/AlpacaFeedTestIT.kt
+++ b/roboquant-extra/test/alpaca/AlpacaFeedTestIT.kt
@@ -16,6 +16,7 @@
 
 package org.roboquant.alpaca
 
+import org.junit.Before
 import org.roboquant.common.*
 import org.roboquant.feeds.*
 import java.time.Duration
@@ -28,9 +29,15 @@ internal class AlpacaFeedTestIT {
 
     private val liveTestTime = 30.seconds
 
+    @Before
+    fun validateEnv() {
+        require(System.getenv("TEST_ALPACA").isNotEmpty()) {
+            "Missing TEST_ALPACA environment variable"
+        }
+    }
+
     @Test
     fun test() {
-        System.getenv("TEST_ALPACA") ?: return
         val feed = AlpacaLiveFeed()
         val assets = feed.availableAssets
         val apple = assets.getBySymbol("AAPL")
@@ -49,7 +56,6 @@ internal class AlpacaFeedTestIT {
 
     @Test
     fun test2() {
-        System.getenv("TEST_ALPACA") ?: return
         val feed = AlpacaLiveFeed()
         feed.subscribe("AAPL")
         val actions = feed.filter<PriceAction>(Timeframe.next(liveTestTime))
@@ -64,7 +70,6 @@ internal class AlpacaFeedTestIT {
 
     @Test
     fun testHistoricFeed() {
-        System.getenv("TEST_ALPACA") ?: return
         val feed = AlpacaHistoricFeed()
         val assets = feed.availableAssets
         assertTrue(assets.isNotEmpty())
@@ -86,7 +91,6 @@ internal class AlpacaFeedTestIT {
 
     @Test
     fun testHistoricQuotes() {
-        System.getenv("TEST_ALPACA") ?: return
         val feed = AlpacaHistoricFeed()
         val tf = Timeframe.past(10.days) - 30.minutes
         feed.retrieveQuotes("AAPL", timeframe = tf)
@@ -95,7 +99,6 @@ internal class AlpacaFeedTestIT {
 
     @Test
     fun testHistoricTrades() {
-        System.getenv("TEST_ALPACA") ?: return
         val feed = AlpacaHistoricFeed()
         val tf = Timeframe.past(10.days) - 30.minutes
         feed.retrieveTrades("AAPL", timeframe = tf)
@@ -104,7 +107,6 @@ internal class AlpacaFeedTestIT {
 
     @Test
     fun testHistoricBars() {
-        System.getenv("TEST_ALPACA") ?: return
         val feed = AlpacaHistoricFeed()
         val tf = Timeframe.past(10.days) - 30.minutes
         feed.retrieveBars("AAPL", timeframe = tf)
@@ -113,7 +115,6 @@ internal class AlpacaFeedTestIT {
 
     @Test
     fun testHistoricBarsWithTimePeriodDuration() {
-        System.getenv("TEST_ALPACA") ?: return
         val feed = AlpacaHistoricFeed()
         val tf = Timeframe.past(10.days) - 30.minutes
         feed.retrieveBars("AAPL",
@@ -127,7 +128,6 @@ internal class AlpacaFeedTestIT {
 
     @Test
     fun test3() {
-        System.getenv("TEST_ALPACA") ?: return
         val feed = AlpacaLiveFeed(autoConnect = false)
         feed.connect()
         feed.subscribeAll()

--- a/roboquant-extra/test/alpaca/AlpacaFeedTestIT.kt
+++ b/roboquant-extra/test/alpaca/AlpacaFeedTestIT.kt
@@ -18,6 +18,7 @@ package org.roboquant.alpaca
 
 import org.roboquant.common.*
 import org.roboquant.feeds.*
+import java.time.Duration
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -108,6 +109,20 @@ internal class AlpacaFeedTestIT {
         val tf = Timeframe.past(10.days) - 30.minutes
         feed.retrieveBars("AAPL", timeframe = tf)
         testResult<PriceBar>(feed, tf)
+    }
+
+    @Test
+    fun testHistoricBarsWithTimePeriodDuration() {
+        System.getenv("TEST_ALPACA") ?: return
+        val feed = AlpacaHistoricFeed()
+        val tf = Timeframe.past(10.days) - 30.minutes
+        feed.retrieveBars("AAPL",
+            timeframe = tf,
+            period = AlpacaPeriod.MINUTE,
+            barTimePeriodDuration = 5)
+
+        val actions = feed.filter<PriceAction>()
+        assertEquals(5, Duration.between(actions[0].first, actions[1].first).toMinutes())
     }
 
     @Test


### PR DESCRIPTION
Simply added the missing parameter, also included a minor test cleanup.

fixes #11 