### PR TITLE
create .cache files containing indexes when loading avro files

### DIFF
--- a/roboquant/src/main/kotlin/org/roboquant/common/Timeframe.kt
+++ b/roboquant/src/main/kotlin/org/roboquant/common/Timeframe.kt
@@ -16,6 +16,7 @@
 
 package org.roboquant.common
 
+import java.io.Serializable
 import java.time.*
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -39,7 +40,7 @@ import kotlin.random.Random
  * @property end end time of timeframe
  * @property inclusive should te [end] time be inclusive, default is false
  */
-data class Timeframe(val start: Instant, val end: Instant, val inclusive: Boolean = false) {
+data class Timeframe(val start: Instant, val end: Instant, val inclusive: Boolean = false) : Serializable {
 
     /**
      * Duration of timeframe

--- a/roboquant/src/test/kotlin/org/roboquant/feeds/AvroFeedTest.kt
+++ b/roboquant/src/test/kotlin/org/roboquant/feeds/AvroFeedTest.kt
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2020-2023 Neural Layer
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,7 +73,7 @@ class AvroFeedTest {
     @Test
     fun avroStep2() {
         val feed2 = AvroFeed(Path(fileName))
-
+        assertTrue(File(fileName + AvroFeed.CACHE_SUFFIX).isFile)
         runBlocking {
             var past = Instant.MIN
             var cnt = 0


### PR DESCRIPTION
Increased load time for a 4GB file from 130 seconds to 4 seconds after cache file created

That's a 30X speed increase! 🚀 

Feel free to change and rearrange. The cache file stores a hash of just the first and last megabytes of the .avro file for comparison..maybe you have better ideas how to handle 