### PR TITLE
Fix signalResolver invocation syntax in strategy classes

### DIFF
--- a/roboquant/src/main/kotlin/org/roboquant/strategies/CombinedStrategy.kt
+++ b/roboquant/src/main/kotlin/org/roboquant/strategies/CombinedStrategy.kt
@@ -42,7 +42,7 @@ open class CombinedStrategy(val strategies: Collection<Strategy>, private val si
             val s = strategy.createSignals(event)
             signals.addAll(s)
         }
-        return signalResolver?.let { signals } ?: signals
+        return signalResolver?.let { signals.it() } ?: signals
     }
 
 

--- a/roboquant/src/main/kotlin/org/roboquant/strategies/ParallelStrategy.kt
+++ b/roboquant/src/main/kotlin/org/roboquant/strategies/ParallelStrategy.kt
@@ -63,7 +63,7 @@ class ParallelStrategy(val strategies: Collection<Strategy>, private val signalR
             }
             deferredList.forEach { signals.addAll(it.await()) }
         }
-        return signalResolver?.let { signals } ?: signals
+        return signalResolver?.let { signals.it() } ?: signals
     }
 
 }

--- a/roboquant/src/test/kotlin/org/roboquant/strategies/CombinedSignalStrategyTest.kt
+++ b/roboquant/src/test/kotlin/org/roboquant/strategies/CombinedSignalStrategyTest.kt
@@ -19,6 +19,7 @@ package org.roboquant.strategies
 import org.roboquant.TestData
 import org.roboquant.common.Event
 import org.roboquant.common.Signal
+import org.roboquant.common.Stock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -38,24 +39,34 @@ internal class CombinedSignalStrategyTest {
     fun test() {
         val s1 = MyStrategy()
         val s2 = MyStrategy()
-        val s = CombinedStrategy(s1, s2)
+
+        val signal = Signal(asset = Stock("A"), rating = 999.0)
+        val resolver: SignalResolver = { listOf(signal) }
+        val s = CombinedStrategy(s1, s2, signalResolver = resolver)
         assertEquals(2, s.strategies.size)
 
         val signals = mutableListOf<Signal>()
         for (event in TestData.events(10)) signals += s.createSignals(event)
-        assertTrue(signals.isEmpty())
+
+        val expected = (1..10).map { signal }
+        assertEquals(expected, signals)
     }
 
     @Test
     fun test2() {
         val s1 = MyStrategy()
         val s2 = MyStrategy()
-        val s = ParallelStrategy(s1, s2)
+
+        val signal = Signal(asset = Stock("A"), rating = 999.0)
+        val resolver: SignalResolver = { listOf(signal) }
+        val s = ParallelStrategy(s1, s2, signalResolver = resolver)
         assertEquals(2, s.strategies.size)
 
         val signals = mutableListOf<Signal>()
         for (event in TestData.events(10)) signals += s.createSignals(event)
-        assertTrue(signals.isEmpty())
+
+        val expected = (1..10).map { signal }
+        assertEquals(expected, signals)
     }
 
 


### PR DESCRIPTION
- Fixed incorrect lambda invocation syntax in CombinedStrategy and ParallelStrategy
- Changed from `.let { signals }` to `.let { signals.it() }` for proper SignalResolver usage
- Added unit tests to verify signalResolver functionality with custom resolver